### PR TITLE
Migrate slim deploy workflows to pnpm

### DIFF
--- a/.github/workflows/deploy-slim.yml
+++ b/.github/workflows/deploy-slim.yml
@@ -14,14 +14,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.3
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.1
 
       - name: Clone and install SLIM dependencies
         run: |
           git clone --branch "$SLIM_BRANCH" https://github.com/ImagingDataCommons/slim.git
           cd slim
-          bun install --frozen-lockfile
+          pnpm install --frozen-lockfile
         env:
           SLIM_BRANCH: ${{ vars.SLIM_BRANCH || 'master' }}
 
@@ -30,7 +32,7 @@ jobs:
           cd slim
           wget -O ./firebase.json "${{ vars.SLIM_FIREBASE_JSON_URL }}"
           wget -O ./public/config/test.js "${{ vars.SLIM_CONFIG_JS_URL }}"
-          REACT_APP_CONFIG=test PUBLIC_URL=/ bun run build
+          REACT_APP_CONFIG=test PUBLIC_URL=/ pnpm run build
 
       - name: Deploy to Firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.10.0

--- a/.github/workflows/deploy-with-dmv-proxy.yml
+++ b/.github/workflows/deploy-with-dmv-proxy.yml
@@ -14,34 +14,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.3
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.1
 
       - name: Clone and install SLIM dependencies
         run: |
           git clone --branch "$SLIM_BRANCH" https://github.com/ImagingDataCommons/slim.git
           cd slim
-          bun install --frozen-lockfile
+          pnpm install --frozen-lockfile
         env:
           SLIM_BRANCH: ${{ vars.SLIM_BRANCH || 'master' }}
 
-      - name: Clone and install dicom-microscopy-viewer dependencies
+      - name: Clone, install, and build dicom-microscopy-viewer
         run: |
           git clone --branch "$DMV_BRANCH" https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git
           cd dicom-microscopy-viewer
-          bun install --frozen-lockfile
-          bun link
-          bun run build
+          pnpm install --frozen-lockfile
+          pnpm run build
         env:
           DMV_BRANCH: ${{ vars.DMV_BRANCH || 'master' }}
 
-      - name: Build slim
+      - name: Build slim with linked dicom-microscopy-viewer
         run: |
           cd slim
-          bun link dicom-microscopy-viewer
+          pnpm link ../dicom-microscopy-viewer
+          pnpm install --frozen-lockfile
           wget -O ./firebase.json "${{ vars.SLIM_FIREBASE_JSON_URL }}"
           wget -O ./public/config/test.js "${{ vars.SLIM_PROXY_CONFIG_JS_URL }}"
-          REACT_APP_CONFIG=test PUBLIC_URL=/ bun run build
+          REACT_APP_CONFIG=test PUBLIC_URL=/ pnpm run build
 
       - name: Deploy to Firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.10.0

--- a/.github/workflows/deploy-with-dmv.yml
+++ b/.github/workflows/deploy-with-dmv.yml
@@ -16,34 +16,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.3
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.1
 
       - name: Clone and install SLIM dependencies
         run: |
           git clone --branch "$SLIM_BRANCH" https://github.com/ImagingDataCommons/slim.git
           cd slim
-          bun install --frozen-lockfile
+          pnpm install --frozen-lockfile
         env:
           SLIM_BRANCH: ${{ vars.SLIM_BRANCH || 'master' }}
 
-      - name: Clone and install dicom-microscopy-viewer dependencies
+      - name: Clone, install, and build dicom-microscopy-viewer
         run: |
           git clone --branch "$DMV_BRANCH" https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git
           cd dicom-microscopy-viewer
-          bun install --frozen-lockfile
-          bun link
-          bun run build
+          pnpm install --frozen-lockfile
+          pnpm run build
         env:
           DMV_BRANCH: ${{ vars.DMV_BRANCH || 'master' }}
 
-      - name: Build slim
+      - name: Build slim with linked dicom-microscopy-viewer
         run: |
           cd slim
-          bun link dicom-microscopy-viewer
+          pnpm link ../dicom-microscopy-viewer
+          pnpm install --frozen-lockfile
           wget -O ./firebase.json "${{ vars.SLIM_FIREBASE_JSON_URL }}"
           wget -O ./public/config/test.js "${{ vars.SLIM_CONFIG_JS_URL }}"
-          REACT_APP_CONFIG=test PUBLIC_URL=/ bun run build
+          REACT_APP_CONFIG=test PUBLIC_URL=/ pnpm run build
 
       - name: Deploy to Firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.10.0

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ This repository contains the following GitHub Actions for automated deployment a
 - **slim/deploy-with-dmv**  
   Deploys the latest version of [Slim Viewer](https://github.com/ImagingDataCommons/slim) along with the latest [DICOM Microscopy Viewer](https://github.com/ImagingDataCommons/dicom-microscopy-viewer).
 
+### Slim and DICOM Microscopy Viewer (pnpm)
+
+[Slim](https://github.com/ImagingDataCommons/slim) and [DICOM Microscopy Viewer](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) use **pnpm** (`packageManager: pnpm@10.34.1`). The `slim/deploy*` workflows install dependencies with `pnpm install --frozen-lockfile`.
+
+The `slim/deploy-with-dmv*` workflows clone both repositories as siblings, build DMV, then link it into Slim for the production build:
+
+```sh
+cd dicom-microscopy-viewer && pnpm install --frozen-lockfile && pnpm run build
+cd ../slim && pnpm link ../dicom-microscopy-viewer && pnpm install --frozen-lockfile
+```
+
+With pnpm 10, `pnpm link` records the link in the local install only; `pnpm install` must run immediately afterward so `node_modules` resolves to the sibling DMV clone (not the registry copy under `.pnpm`). Do not commit `link:` overrides from local linking into Slim's `package.json` or `pnpm-lock.yaml`.
+
 ### Deployment URL
 
 Actions deploy:


### PR DESCRIPTION
## Summary
- Replace `bun install` / `bun link` / `bun run build` with **pnpm 10.34.1** in all three slim deploy workflows (`deploy-slim`, `deploy-with-dmv`, `deploy-with-dmv-proxy`), matching the package manager migration in [slim](https://github.com/ImagingDataCommons/slim) and [dicom-microscopy-viewer](https://github.com/ImagingDataCommons/dicom-microscopy-viewer).
- Fix DMV linking for `deploy-with-dmv*`: clone and build DMV as a sibling repo, then `pnpm link ../dicom-microscopy-viewer` followed by `pnpm install --frozen-lockfile` before building slim (pnpm 10 requires install after link to swap `node_modules` off the registry copy).
- Remove `bun link` from the DMV step — path-based linking from slim is sufficient in CI.
- Document the pnpm linking flow in the README.

## Context
The previous workflows used Bun, but slim/DMV now declare `packageManager: pnpm@10.34.1`. The scheduled `slim/deploy-with-dmv` job was failing for the same class of package-manager mismatch described in [issues/1](issues/1).

Locally committed `link:` overrides in slim's `package.json` also broke slim CI (`Can't resolve 'dicom-microscopy-viewer'`); those overrides must not be committed — CI clones fresh repos and links at build time instead.

## Test plan
- [ ] Run `slim/deploy` workflow_dispatch against `master` slim branch
- [ ] Run `slim/deploy-with-dmv` workflow_dispatch with default `SLIM_BRANCH` / `DMV_BRANCH`
- [ ] Confirm slim build resolves `dicom-microscopy-viewer` from the sibling clone (not `.pnpm` registry path)
- [ ] Confirm Firebase deploy succeeds